### PR TITLE
Changed Actions to SHA tags

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -14,19 +14,19 @@ jobs:
       packages: write
     steps:
       # Checks out the main branch of the repository to the runner
-      - uses: actions/checkout@v3.5.2
+      - uses: actions/checkout@83b7061638ee4956cf7545a6f7efe594e5ad0247 # v3.5.1
 
       # Sets up the QEMU emulator that emulates different architectures
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.1.0
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
 
       # Sets up the Docker Buildx plugin to build multi-architecture Docker images
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.5.0
+        uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7 # v2.4.1
 
       # Authenticates with Docker Hub
       - name: Login to Docker Hub
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1.4.1
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -34,7 +34,7 @@ jobs:
 
       # Authenticates with the GitHub Container Registry
       - name: Login to GitHub Package Registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # v2.0.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4.3.0
+        uses: docker/metadata-action@05d22bf31770de02e20c67c70365453e00227f61 # v4.2.0
         with:
           images: |
             ${{ github.repository }}
@@ -55,7 +55,7 @@ jobs:
       # - 'latest' for successful builds on the main branch.
       # - '<short_branch_name>' pushes to non-main branches.
       - name: Build and push Docker image
-        uses: docker/build-push-action@vv3.3.1
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v3.3.1
         with:
           context: .
           push: true

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       # Git Checkout
       - name: Checkout Code
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: ${{ github.event_name == 'pull_request' && '0' || '1' }}
@@ -40,7 +40,7 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/flavors/
-        uses: oxsecurity/megalinter/flavors/documentation@v6.22.2
+        uses: oxsecurity/megalinter/flavors/documentation@fe568b3592efcd04d21632d99501fc120df8110a # v6.22.1
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/
@@ -53,7 +53,7 @@ jobs:
       # Upload MegaLinter artifacts
       - name: Archive production artifacts
         if: ${{ success() }} || ${{ failure() }}
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: MegaLinter reports
           path: |
@@ -68,7 +68,7 @@ jobs:
           env.APPLY_FIXES_MODE == 'pull_request' &&
           (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) &&
           (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
-        uses: peter-evans/create-pull-request@v5.0.0
+        uses: peter-evans/create-pull-request@5b4a9f6a9e2af26e5f02351490b90d01eb8ec1e5 # v5.0.0
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           commit-message: "[MegaLinter] Apply linters automatic fixes"
@@ -92,7 +92,7 @@ jobs:
         run: sudo chown -Rc $UID .git/
       - name: Commit and push applied linter fixes
         if: always() && steps.pc.conclusion == 'success'
-        uses: stefanzweifel/git-auto-commit-action@v4.16.0
+        uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4.16.0
         with:
           branch: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref }}
           commit_message: "[MegaLinter] Apply linters fixes"


### PR DESCRIPTION
Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload. 