### PR TITLE
feat: remove armv7 as no longer supported

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
 


### PR DESCRIPTION
https://www.linuxserver.io/blog/a-farewell-to-arm-hf
As per the above article, armv7 is no longer supported.