### PR TITLE
fix: update GitHub release action to use 'token' instead of 'env' for PAT

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -86,5 +86,4 @@ jobs:
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           tag_name: ${{ steps.bumpTag.outputs.new_tag }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+          token: ${{ secrets.PAT }}


### PR DESCRIPTION
fix: update GitHub release action to use 'token' instead of 'env' for PAT

#### PR Classification
Bug fix to ensure correct authentication variable is used in the GitHub Actions workflow for release creation.

#### PR Summary
This pull request updates the deploy-docker-image.yml workflow to use the correct authentication input for the release creation step.
- deploy-docker-image.yml: Replaces GITHUB_TOKEN with token when passing the PAT secret to softprops/action-gh-release.

## Summary by Sourcery

Bug Fixes:
- Fix release workflow authentication by passing the PAT via the action's token input instead of environment variables.