### PR TITLE
chore(ci): add cleanup step for unused Docker images and containers

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -69,6 +69,26 @@ jobs:
               github.ref
             }}
 
+      # Free up disk space before running MegaLinter
+      - name: Cleanup Unused Docker Images and Containers
+        run: |
+          echo "=== Docker Images Before Cleanup ==="
+          docker images
+
+          echo ""
+          echo "=== Cleaning Docker Images ==="
+          docker image prune -af || true
+          docker container prune -f || true
+
+          echo ""
+          echo "=== Docker Images After Cleanup ==="
+          docker images
+
+          echo ""
+          echo "=== Disk Usage After Cleanup ==="
+          df -h
+          docker system df
+
       # MegaLinter
       - name: MegaLinter
         # More info at https://megalinter.io/flavors/
@@ -199,4 +219,4 @@ jobs:
           commit_message: "[MegaLinter] Apply linters fixes"
           commit_user_name: megalinter-bot
           commit_user_email: 129584137+megalinter-bot@users.noreply.github.com
-          file_pattern: '. :!.github/workflows/**'
+          file_pattern: ". :!.github/workflows/**"


### PR DESCRIPTION
chore(ci): add cleanup step for unused Docker images and containers

#### PR Classification
This pull request introduces a CI workflow improvement and a minor configuration formatting update.

#### PR Summary
A cleanup step was added to the CI pipeline to manage Docker resources before running MegaLinter, and a formatting update was made in the MegaLinter configuration.
- CI workflow: Added a job step to clean up unused Docker images and containers, displaying disk usage before and after.
- MegaLinter configuration: Changed file_pattern value to use double quotes instead of single quotes.

## Summary by Sourcery

Add a Docker resource cleanup step to the MegaLinter CI workflow and align MegaLinter configuration file pattern quoting.

Enhancements:
- Update MegaLinter configuration to use consistent double-quoted file_pattern syntax.

CI:
- Add a CI step to prune unused Docker images and containers and report disk usage before running MegaLinter.