### PR TITLE
fix(healthcheck): update healthcheck command syntax in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,7 @@ RUN \
 # Add a health check command to ensure the container is running correctly
 HEALTHCHECK --interval=15m \
     --timeout=3s \
-    CMD ps -ef | grep cron || exit 1 \
-    && ping -c 1 www.packtpub.com >/dev/null 2>&1 || exit 1
+    CMD ["sh", "-c", "ps -ef | grep cron || exit 1 && ping -c 1 www.packtpub.com >/dev/null 2>&1 || exit 1"]
 
 # Volume where the config file and crontab
 VOLUME /config


### PR DESCRIPTION
Switch HEALTHCHECK to exec form in Dockerfile

Updated the Dockerfile HEALTHCHECK from shell to exec (JSON array) form for improved reliability and compatibility. Replaced inline shell command with CMD ["sh", "-c", "ps -ef | grep cron || exit 1 && ping -c 1 www.packtpub.com >/dev/null 2>&1 || exit 1"].

#### PR Classification
Code cleanup to improve Dockerfile reliability and maintainability.

#### PR Summary
The Dockerfile HEALTHCHECK command was refactored from shell form to exec form for more predictable execution and reduced shell parsing issues.
- Dockerfile: Updated HEALTHCHECK to use exec (JSON array) form instead of shell form.
